### PR TITLE
Windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mcp_server_exa_search"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "schemars",
  "serde",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ef88a8e5aeff67b0996b1795d56338f04c02de95f1f147577944aa37b801d6"
+checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = "1.0"
 schemars = "0.8"
-zed_extension_api = "0.5.0"
+zed_extension_api = "0.7.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "mcp-server-exa-search"
 name = "Exa Search + Crawling MCP Server"
 description = "Model Context Protocol Server for Exa Search and Crawling"
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = ["Felix Zeller <felix@exa.ai>"]
 repository = "https://github.com/exa-labs/zed-exa-mcp-extension"


### PR DESCRIPTION
This PR bumps the `zed_extension_api` crate to make `env::current_dir` work correctly on Windows. I've also bumped the extension version so that we're ready to publish a new version.