### PR TITLE
fix: update server path and version checking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp_server_exa_search"
-version = "0.0.3"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "mcp-server-exa-search"
 name = "Exa Search + Crawling MCP Server"
 description = "Model Context Protocol Server for Exa Search and Crawling"
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Felix Zeller <felix@exa.ai>"]
 repository = "https://github.com/exa-labs/zed-exa-mcp-extension"

--- a/src/mcp_server_exa_search.rs
+++ b/src/mcp_server_exa_search.rs
@@ -7,8 +7,7 @@ use zed_extension_api::{
 };
 
 const PACKAGE_NAME: &str = "exa-mcp-server";
-const PACKAGE_VERSION: &str = "latest"; // Using latest version as recommended
-const SERVER_PATH: &str = "node_modules/exa-mcp-server/build/index.js";
+const SERVER_PATH: &str = "node_modules/exa-mcp-server/.smithery/stdio/index.cjs";
 
 struct ExaSearchModelContextExtension;
 
@@ -27,9 +26,10 @@ impl zed::Extension for ExaSearchModelContextExtension {
         _context_server_id: &ContextServerId,
         project: &Project,
     ) -> Result<Command> {
+        let latest_version = zed::npm_package_latest_version(PACKAGE_NAME)?;
         let version = zed::npm_package_installed_version(PACKAGE_NAME)?;
-        if version.as_deref() != Some(PACKAGE_VERSION) {
-            zed::npm_install_package(PACKAGE_NAME, PACKAGE_VERSION)?;
+        if version.as_deref() != Some(latest_version.as_ref()) {
+            zed::npm_install_package(PACKAGE_NAME, &latest_version)?;
         }
 
         let settings = ContextServerSettings::for_project("mcp-server-exa-search", project)?;


### PR DESCRIPTION
## Summary

Fixes the extension to work with exa-mcp-server v3.0.6+ which restructured to use Smithery CLI bundling.

## Changes

- **Update SERVER_PATH**: Changed from `build/index.js` to `.smithery/stdio/index.cjs` to match the new package structure
- **Fix version checking**: Properly compare installed vs latest versions instead of comparing to the string `"latest"`
- **Bump extension version**: Updated from 0.0.4 to 0.0.5

## Problem

The extension was broken because:
1. The `exa-mcp-server` package no longer has `build/index.js` - it now uses `.smithery/stdio/index.cjs`
2. Version checking compared the installed version (e.g., "3.0.6") to the string "latest", which would never match and caused unnecessary reinstalls on every invocation

## Verification

- ✅ Verified package structure with npm v3.0.6
- ✅ Confirmed binary location and executable permissions
- ✅ Tested server starts successfully
- ✅ Tool arguments remain compatible

## Related

May help with timeout issues reported in #7